### PR TITLE
fix: incorrect mobile menu z-index

### DIFF
--- a/client/src/components/home-section/HomeSectionComponent.tsx
+++ b/client/src/components/home-section/HomeSectionComponent.tsx
@@ -8,7 +8,7 @@ const HomeSectionComponent = (props: PropsWithChildren<Props>) => {
   const { title, children } = props;
 
   return (
-    <div className="w-full flex flex-col gap-3">
+    <div className="w-full flex flex-col gap-5">
       <h1 className="text-2xl font-semibold text-rose-700 text-center">{title}</h1>
       <div>{children}</div>
     </div>

--- a/client/src/components/navbar/mobile-navbar/MobileNavBarComponent.tsx
+++ b/client/src/components/navbar/mobile-navbar/MobileNavBarComponent.tsx
@@ -45,9 +45,9 @@ const MobileNavBarComponent = (props: Props) => {
         </div>
       </div>
       {state.visible && (
-        <div className="fixed w-full h-screen left-0 top-0 overflow-hidden">
-          <div className="w-full h-full pt-20">
-            <div className="w-full h-full bg-white overflow-hidden">
+        <div className="fixed w-full h-screen left-0 top-0 overflow-hidden z-40">
+          <div className="relative w-full h-full pt-20">
+            <div className="relative w-full h-full bg-white overflow-hidden">
               <div className="w-full h-full px-3 py-2 overflow-auto flex flex-col gap-2">
                 {
                     Renderer.MenuItems()


### PR DESCRIPTION
Fixed incorrect mobile menu z-index, where the menu was displayed behind all components